### PR TITLE
Security upgrade ruby from 3.0.1-alpine3.13 to 3.0-alpine3.13 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.1-alpine3.13
+FROM ruby:3.0-alpine3.13
 
 LABEL org.opencontainers.image.source=https://github.com/mongodb-developer/get-started-ruby
 


### PR DESCRIPTION
Upgrading to ruby:3.0-alpine3.13, as this image has only 0 known vulnerabilities.

<img width="711" alt="Screen Shot 2022-02-24 at 8 31 04 PM" src="https://user-images.githubusercontent.com/90247/155654073-ceb58071-4952-42cd-9c25-e8dc6f9c5dd7.png">
